### PR TITLE
ENTMQBR-3081: Updated service yaml to use AMQ Broker 7.5

### DIFF
--- a/service.amqp.yaml
+++ b/service.amqp.yaml
@@ -1,67 +1,32 @@
 kind: List
 apiVersion: v1
 metadata:
-  name: amq63-image-stream
+  name: amq-broker-7-image-streams
   annotations:
-    description: ImageStream definition for Red Hat JBoss AMQ 6.3.
+    description: ImageStream definitions for Red Hat AMQ Broker 7.5 Container Image
     openshift.io/provider-display-name: Red Hat, Inc.
 items:
 - kind: ImageStream
   apiVersion: v1
   metadata:
-    name: jboss-amq-63
+    name: amq-broker
     annotations:
-      openshift.io/display-name: Red Hat JBoss A-MQ 6.3
+      openshift.io/display-name: Red Hat AMQ Broker 7.5
       openshift.io/provider-display-name: Red Hat, Inc.
-      version: 1.4.12
-  labels:
-    xpaas: 1.4.12
   spec:
+    lookupPolicy:
+      local: true  
     tags:
-    - name: '1.0'
+    - name: '7.5'
       annotations:
-        description: JBoss A-MQ 6.3 broker image.
-        iconClass: icon-amq
-        tags: messaging,amq,jboss,hidden
-        supports: amq:6.3,messaging
-        version: '1.0'
-        openshift.io/display-name: Red Hat JBoss A-MQ 6.3
+        description: Red Hat AMQ Broker 7.5.0 image.
+        iconClass: icon-jboss
+        tags: messaging,amq,jboss,xpaas
+        supports: amq:7.5,messaging:7.5
+        version: '7.5'
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.0
-    - name: '1.1'
-      annotations:
-        description: JBoss A-MQ 6.3 broker image.
-        iconClass: icon-amq
-        tags: messaging,amq,jboss,hidden
-        supports: amq:6.3,messaging
-        version: '1.1'
-        openshift.io/display-name: Red Hat JBoss A-MQ 6.3
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.1
-    - name: '1.2'
-      annotations:
-        description: JBoss A-MQ 6.3 broker image.
-        iconClass: icon-amq
-        tags: messaging,amq,jboss,hidden
-        supports: amq:6.3,messaging
-        version: '1.2'
-        openshift.io/display-name: Red Hat JBoss A-MQ 6.3
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.2
-    - name: '1.3'
-      annotations:
-        description: JBoss A-MQ 6.3 broker image.
-        iconClass: icon-amq
-        tags: messaging,amq,jboss,hidden
-        supports: amq:6.3,messaging
-        version: '1.3'
-        openshift.io/display-name: Red Hat JBoss A-MQ 6.3
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+        name: registry.redhat.io/amq7/amq-broker:7.5
 - kind: Service
   apiVersion: v1
   spec:
@@ -137,86 +102,77 @@ items:
     annotations:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
       description: Supports node discovery for mesh formation.
-- kind: DeploymentConfig
-  apiVersion: v1
+- apiVersion: v1
+  kind: DeploymentConfig
   metadata:
-    name: "work-queue-broker-amq"
     labels:
-      application: "work-queue-broker"
-      app: amq63-basic
+      application: work-queue-broker
+    name: "work-queue-broker-amq"
   spec:
-    strategy:
-      type: Rolling
-      rollingParams:
-        maxSurge: 0
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - "work-queue-broker-amq"
-        from:
-          kind: ImageStreamTag
-          name: jboss-amq-63:1.3
-    - type: ConfigChange
     replicas: 1
     selector:
       deploymentConfig: "work-queue-broker-amq"
+    strategy:
+      rollingParams:
+        maxSurge: 0
+      type: Rolling
     template:
       metadata:
-        name: "work-queue-broker-amq"
         labels:
-          app: amq63-basic
+          application: work-queue-broker
           deploymentConfig: "work-queue-broker-amq"
-          application: "work-queue-broker"
+        name: "work-queue-broker-amq"
       spec:
-        terminationGracePeriodSeconds: 60
         containers:
-        - name: "work-queue-broker-amq"
-          image: jboss-amq-63
+        - env:
+          - name: AMQ_USER
+            value: "work-queue"
+          - name: AMQ_PASSWORD
+            value: "work-queue"
+          - name: AMQ_ROLE
+            value: "admin"
+          - name: AMQ_NAME
+            value: "amq-broker"
+          - name: AMQ_TRANSPORTS
+            value: "amqp,mqtt,stomp"
+          - name: AMQ_QUEUES
+            value: "work-queue/requests,work-queue/responses"
+          - name: AMQ_ADDRESSES
+            value: "work-queue/worker-updates"
+          - name: AMQ_REQUIRE_LOGIN
+            value: "false"
+          - name: AMQ_EXTRA_ARGS
+            value: "--no-autotune"
+          - name: AMQ_ENABLE_METRICS_PLUGIN
+            value: "false"
+          - name: AMQ_JOURNAL_TYPE
+            value: "nio"
+          image: "registry.redhat.io/amq7/amq-broker:7.5"
           imagePullPolicy: Always
           readinessProbe:
             exec:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/amq/bin/readinessProbe.sh"
+              - "/opt/amq/bin/readinessProbe.sh"            
+          name: "work-queue-broker-amq"
           ports:
-          - name: jolokia
-            containerPort: 8778
+          - containerPort: 8161
+            name: console-jolokia
             protocol: TCP
-          - name: amqp
-            containerPort: 5672
+          - containerPort: 5672
+            name: amqp
             protocol: TCP
-          - name: mqtt
-            containerPort: 1883
+          - containerPort: 1883
+            name: mqtt
             protocol: TCP
-          - name: stomp
-            containerPort: 61613
+          - containerPort: 61613
+            name: stomp
             protocol: TCP
-          - name: tcp
-            containerPort: 61616
+          - containerPort: 61616
+            name: artemis
             protocol: TCP
-          env:
-          - name: AMQ_USER
-            value: "work-queue"
-          - name: AMQ_PASSWORD
-            value: "work-queue"
-          - name: AMQ_TRANSPORTS
-            value: "amqp"
-          - name: AMQ_QUEUES
-            value: "work-queue/requests,work-queue/responses"
-          - name: AMQ_TOPICS
-            value: "work-queue/worker-updates"
-          - name: AMQ_MESH_DISCOVERY_TYPE
-            value: "dns"
-          - name: AMQ_MESH_SERVICE_NAME
-            value: "work-queue-broker-amq-mesh"
-          - name: AMQ_MESH_SERVICE_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: AMQ_STORAGE_USAGE_LIMIT
-            value: "100 gb"
-          - name: AMQ_QUEUE_MEMORY_LIMIT
-            value: ""
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - type: ConfigChange
+


### PR DESCRIPTION
Updated the service amqp yaml to use the AMQ Broker 7.5 container image instead of the A-MQ Broker 6.3 container image. Created local deployment against OCP 3.11 to test; broker deploys ok, and services look correct for the utilized protocols.
Please review and let me know if there is further work required.