### PR TITLE
Using Kube service binding in order to connect over AMQ 1.0 Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ message protocol to send and receive messages.
 
 ## Prerequisites
 
-* Node.js version 10, 12 or 14
+* Node.js version 12, 14 or 16
 
 * The user has access to an OpenShift instance and is logged in.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ message protocol to send and receive messages.
 
 ## Prerequisites
 
+* Node.js version 10, 12 or 14
+
 * The user has access to an OpenShift instance and is logged in.
 
 * The user has selected a project in which the frontend and backend
@@ -22,7 +24,7 @@ Run the following commands to configure and deploy the applications.
 ```bash
 $ oc create -f service.amqp.yaml
 
-$ ./start-openshift
+$ ./start-openshift.sh
 ```
 ## Modules
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -23,13 +23,23 @@ const crypto = require('crypto');
 const bodyParser = require('body-parser');
 const express = require('express');
 const rhea = require('rhea');
+const serviceBindings = require('kube-service-bindings');
 
 // AMQP
 
-const amqpHost = process.env.MESSAGING_SERVICE_HOST || 'localhost';
-const amqpPort = process.env.MESSAGING_SERVICE_PORT || 5672;
-const amqpUser = process.env.MESSAGING_SERVICE_USER || 'work-queue';
-const amqpPassword = process.env.MESSAGING_SERVICE_PASSWORD || 'work-queue';
+let amqpConnectionBindings;
+
+try {
+  amqpConnectionBindings = serviceBindings.getBinding('AMQP', 'rhea');
+} catch (err) {
+  console.log(err);
+  amqpConnectionBindings = {
+    host: process.env.MESSAGING_SERVICE_HOST || 'localhost',
+    port: process.env.MESSAGING_SERVICE_PORT || 5672,
+    username: process.env.MESSAGING_SERVICE_USER || 'work-queue',
+    password: process.env.MESSAGING_SERVICE_PASSWORD || 'work-queue'
+  };
+}
 
 const id = `frontend-nodejs-${crypto.randomBytes(2).toString('hex')}`;
 const container = rhea.create_container({ id });
@@ -61,8 +71,9 @@ function sendRequests () {
 }
 
 container.on('connection_open', event => {
-  console.log(`${id}: Connected to AMQP messaging service at ${amqpHost}:${amqpPort}`);
-
+  console.log(
+    `${id}: Connected to AMQP messaging service at ${amqpConnectionBindings.host}:${amqpConnectionBindings.port}`
+  );
   requestSender = event.connection.open_sender('work-queue/requests');
   responseReceiver = event.connection.open_receiver({ source: { dynamic: true } });
   workerUpdateReceiver = event.connection.open_receiver('work-queue/worker-updates');
@@ -99,19 +110,14 @@ container.on('message', event => {
   }
 });
 
-const opts = {
-  host: amqpHost,
-  port: amqpPort,
-  username: amqpUser,
-  password: amqpPassword
-};
-
 container.on('error', err => {
   console.log(err);
 });
 
-console.log(`${id}: Attempting to connect to AMQP messaging service at ${amqpHost}:${amqpPort}`);
-container.connect(opts);
+console.log(
+  `${id}: Attempting to connect to AMQP messaging service at ${amqpConnectionBindings.host}:${amqpConnectionBindings.port}`
+);
+container.connect(amqpConnectionBindings);
 
 // HTTP
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "~1.19.0",
         "debug": "^4.3.3",
         "express": "~4.17.1",
+        "kube-service-bindings": "^0.0.8",
         "pino": "^7.5.1",
         "pino-debug": "^2.0.0",
         "pino-pretty": "^7.2.0",
@@ -2636,6 +2637,14 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/kube-service-bindings": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/kube-service-bindings/-/kube-service-bindings-0.0.8.tgz",
+      "integrity": "sha512-JOEhRYvg1JLCEuAH82NE4TOz28Z9nhrxKYGVo34eWe+3Ei2pX9sQtd2LzwPgNBdxoiewki640kDwF8FvwXMqwg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/kubernetes-client": {
@@ -6715,6 +6724,11 @@
       "requires": {
         "json-buffer": "3.0.0"
       }
+    },
+    "kube-service-bindings": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/kube-service-bindings/-/kube-service-bindings-0.0.8.tgz",
+      "integrity": "sha512-JOEhRYvg1JLCEuAH82NE4TOz28Z9nhrxKYGVo34eWe+3Ei2pX9sQtd2LzwPgNBdxoiewki640kDwF8FvwXMqwg=="
     },
     "kubernetes-client": {
       "version": "9.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "body-parser": "~1.19.0",
     "debug": "^4.3.3",
     "express": "~4.17.1",
+    "kube-service-bindings": "^0.0.8",
     "pino": "^7.5.1",
     "pino-debug": "^2.0.0",
     "pino-pretty": "^7.2.0",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "~1.19.0",
         "debug": "^4.3.3",
         "express": "~4.17.1",
+        "kube-service-bindings": "^0.0.8",
         "pino": "^7.5.1",
         "pino-debug": "^2.0.0",
         "pino-pretty": "^7.2.0",
@@ -2632,6 +2633,14 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/kube-service-bindings": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/kube-service-bindings/-/kube-service-bindings-0.0.8.tgz",
+      "integrity": "sha512-JOEhRYvg1JLCEuAH82NE4TOz28Z9nhrxKYGVo34eWe+3Ei2pX9sQtd2LzwPgNBdxoiewki640kDwF8FvwXMqwg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/kubernetes-client": {
@@ -6715,6 +6724,11 @@
       "requires": {
         "json-buffer": "3.0.0"
       }
+    },
+    "kube-service-bindings": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/kube-service-bindings/-/kube-service-bindings-0.0.8.tgz",
+      "integrity": "sha512-JOEhRYvg1JLCEuAH82NE4TOz28Z9nhrxKYGVo34eWe+3Ei2pX9sQtd2LzwPgNBdxoiewki640kDwF8FvwXMqwg=="
     },
     "kubernetes-client": {
       "version": "9.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -28,6 +28,7 @@
     "body-parser": "~1.19.0",
     "debug": "^4.3.3",
     "express": "~4.17.1",
+    "kube-service-bindings": "^0.0.8",
     "pino": "^7.5.1",
     "pino-debug": "^2.0.0",
     "pino-pretty": "^7.2.0",


### PR DESCRIPTION
* This PR does not work with RabbitMQ, due to limitations of rabbitmq_amqp1_0
* For using kube-service-binding in RabbitMQ over amq protocol, is supported on this PR https://github.com/nodeshift-starters/nodejs-messaging-work-queue/pull/51
* AMQ broker does not support kube-service-bindings yet